### PR TITLE
Renames for javax-to-jakarta on signature files

### DIFF
--- a/jaxb-tck/tests/api/signaturetest/sig/9.0/jakarta.xml.bind.sig
+++ b/jaxb-tck/tests/api/signaturetest/sig/9.0/jakarta.xml.bind.sig
@@ -159,30 +159,30 @@ meth public void checkGuard(java.lang.Object)
 supr java.lang.Object
 hfds name,serialVersionUID
 
-CLSS public abstract javax.xml.bind.Binder<%0 extends java.lang.Object>
+CLSS public abstract jakarta.xml.bind.Binder<%0 extends java.lang.Object>
 cons public Binder()
-meth public abstract <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal({javax.xml.bind.Binder%0},java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object getJAXBNode({javax.xml.bind.Binder%0})
-meth public abstract java.lang.Object getProperty(java.lang.String) throws javax.xml.bind.PropertyException
-meth public abstract java.lang.Object unmarshal({javax.xml.bind.Binder%0}) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object updateJAXB({javax.xml.bind.Binder%0}) throws javax.xml.bind.JAXBException
-meth public abstract javax.xml.bind.ValidationEventHandler getEventHandler() throws javax.xml.bind.JAXBException
+meth public abstract <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal({jakarta.xml.bind.Binder%0},java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object getJAXBNode({jakarta.xml.bind.Binder%0})
+meth public abstract java.lang.Object getProperty(java.lang.String) throws jakarta.xml.bind.PropertyException
+meth public abstract java.lang.Object unmarshal({jakarta.xml.bind.Binder%0}) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object updateJAXB({jakarta.xml.bind.Binder%0}) throws jakarta.xml.bind.JAXBException
+meth public abstract jakarta.xml.bind.ValidationEventHandler getEventHandler() throws jakarta.xml.bind.JAXBException
 meth public abstract javax.xml.validation.Schema getSchema()
-meth public abstract void marshal(java.lang.Object,{javax.xml.bind.Binder%0}) throws javax.xml.bind.JAXBException
-meth public abstract void setEventHandler(javax.xml.bind.ValidationEventHandler) throws javax.xml.bind.JAXBException
-meth public abstract void setProperty(java.lang.String,java.lang.Object) throws javax.xml.bind.PropertyException
+meth public abstract void marshal(java.lang.Object,{jakarta.xml.bind.Binder%0}) throws jakarta.xml.bind.JAXBException
+meth public abstract void setEventHandler(jakarta.xml.bind.ValidationEventHandler) throws jakarta.xml.bind.JAXBException
+meth public abstract void setProperty(java.lang.String,java.lang.Object) throws jakarta.xml.bind.PropertyException
 meth public abstract void setSchema(javax.xml.validation.Schema)
-meth public abstract {javax.xml.bind.Binder%0} getXMLNode(java.lang.Object)
-meth public abstract {javax.xml.bind.Binder%0} updateXML(java.lang.Object) throws javax.xml.bind.JAXBException
-meth public abstract {javax.xml.bind.Binder%0} updateXML(java.lang.Object,{javax.xml.bind.Binder%0}) throws javax.xml.bind.JAXBException
+meth public abstract {jakarta.xml.bind.Binder%0} getXMLNode(java.lang.Object)
+meth public abstract {jakarta.xml.bind.Binder%0} updateXML(java.lang.Object) throws jakarta.xml.bind.JAXBException
+meth public abstract {jakarta.xml.bind.Binder%0} updateXML(java.lang.Object,{jakarta.xml.bind.Binder%0}) throws jakarta.xml.bind.JAXBException
 supr java.lang.Object
 
-CLSS public javax.xml.bind.DataBindingException
+CLSS public jakarta.xml.bind.DataBindingException
 cons public DataBindingException(java.lang.String,java.lang.Throwable)
 cons public DataBindingException(java.lang.Throwable)
 supr java.lang.RuntimeException
 
-CLSS public final javax.xml.bind.DatatypeConverter
+CLSS public final jakarta.xml.bind.DatatypeConverter
 meth public static boolean parseBoolean(java.lang.String)
 meth public static byte parseByte(java.lang.String)
 meth public static byte[] parseBase64Binary(java.lang.String)
@@ -221,11 +221,11 @@ meth public static javax.xml.namespace.QName parseQName(java.lang.String,javax.x
 meth public static long parseLong(java.lang.String)
 meth public static long parseUnsignedInt(java.lang.String)
 meth public static short parseShort(java.lang.String)
-meth public static void setDatatypeConverter(javax.xml.bind.DatatypeConverterInterface)
+meth public static void setDatatypeConverter(jakarta.xml.bind.DatatypeConverterInterface)
 supr java.lang.Object
 hfds SET_DATATYPE_CONVERTER_PERMISSION,theConverter
 
-CLSS public abstract interface javax.xml.bind.DatatypeConverterInterface
+CLSS public abstract interface jakarta.xml.bind.DatatypeConverterInterface
 meth public abstract boolean parseBoolean(java.lang.String)
 meth public abstract byte parseByte(java.lang.String)
 meth public abstract byte[] parseBase64Binary(java.lang.String)
@@ -265,9 +265,9 @@ meth public abstract long parseLong(java.lang.String)
 meth public abstract long parseUnsignedInt(java.lang.String)
 meth public abstract short parseShort(java.lang.String)
 
-CLSS public abstract interface javax.xml.bind.Element
+CLSS public abstract interface jakarta.xml.bind.Element
 
-CLSS public final javax.xml.bind.JAXB
+CLSS public final jakarta.xml.bind.JAXB
 meth public static <%0 extends java.lang.Object> {%%0} unmarshal(java.io.File,java.lang.Class<{%%0}>)
 meth public static <%0 extends java.lang.Object> {%%0} unmarshal(java.io.InputStream,java.lang.Class<{%%0}>)
 meth public static <%0 extends java.lang.Object> {%%0} unmarshal(java.io.Reader,java.lang.Class<{%%0}>)
@@ -286,51 +286,51 @@ supr java.lang.Object
 hfds cache
 hcls Cache
 
-CLSS public abstract javax.xml.bind.JAXBContext
+CLSS public abstract jakarta.xml.bind.JAXBContext
 cons protected JAXBContext()
-fld public final static java.lang.String JAXB_CONTEXT_FACTORY = "javax.xml.bind.context.factory"
-meth public !varargs static javax.xml.bind.JAXBContext newInstance(java.lang.Class<?>[]) throws javax.xml.bind.JAXBException
-meth public <%0 extends java.lang.Object> javax.xml.bind.Binder<{%%0}> createBinder(java.lang.Class<{%%0}>)
-meth public abstract javax.xml.bind.Marshaller createMarshaller() throws javax.xml.bind.JAXBException
-meth public abstract javax.xml.bind.Unmarshaller createUnmarshaller() throws javax.xml.bind.JAXBException
-meth public abstract javax.xml.bind.Validator createValidator() throws javax.xml.bind.JAXBException
+fld public final static java.lang.String JAXB_CONTEXT_FACTORY = "jakarta.xml.bind.context.factory"
+meth public !varargs static jakarta.xml.bind.JAXBContext newInstance(java.lang.Class<?>[]) throws jakarta.xml.bind.JAXBException
+meth public <%0 extends java.lang.Object> jakarta.xml.bind.Binder<{%%0}> createBinder(java.lang.Class<{%%0}>)
+meth public abstract jakarta.xml.bind.Marshaller createMarshaller() throws jakarta.xml.bind.JAXBException
+meth public abstract jakarta.xml.bind.Unmarshaller createUnmarshaller() throws jakarta.xml.bind.JAXBException
+meth public abstract jakarta.xml.bind.Validator createValidator() throws jakarta.xml.bind.JAXBException
  anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="")
-meth public javax.xml.bind.Binder<org.w3c.dom.Node> createBinder()
-meth public javax.xml.bind.JAXBIntrospector createJAXBIntrospector()
-meth public static javax.xml.bind.JAXBContext newInstance(java.lang.Class<?>[],java.util.Map<java.lang.String,?>) throws javax.xml.bind.JAXBException
-meth public static javax.xml.bind.JAXBContext newInstance(java.lang.String) throws javax.xml.bind.JAXBException
-meth public static javax.xml.bind.JAXBContext newInstance(java.lang.String,java.lang.ClassLoader) throws javax.xml.bind.JAXBException
-meth public static javax.xml.bind.JAXBContext newInstance(java.lang.String,java.lang.ClassLoader,java.util.Map<java.lang.String,?>) throws javax.xml.bind.JAXBException
-meth public void generateSchema(javax.xml.bind.SchemaOutputResolver) throws java.io.IOException
+meth public jakarta.xml.bind.Binder<org.w3c.dom.Node> createBinder()
+meth public jakarta.xml.bind.JAXBIntrospector createJAXBIntrospector()
+meth public static jakarta.xml.bind.JAXBContext newInstance(java.lang.Class<?>[],java.util.Map<java.lang.String,?>) throws jakarta.xml.bind.JAXBException
+meth public static jakarta.xml.bind.JAXBContext newInstance(java.lang.String) throws jakarta.xml.bind.JAXBException
+meth public static jakarta.xml.bind.JAXBContext newInstance(java.lang.String,java.lang.ClassLoader) throws jakarta.xml.bind.JAXBException
+meth public static jakarta.xml.bind.JAXBContext newInstance(java.lang.String,java.lang.ClassLoader,java.util.Map<java.lang.String,?>) throws jakarta.xml.bind.JAXBException
+meth public void generateSchema(jakarta.xml.bind.SchemaOutputResolver) throws java.io.IOException
 supr java.lang.Object
 
-CLSS public javax.xml.bind.JAXBElement<%0 extends java.lang.Object>
-cons public JAXBElement(javax.xml.namespace.QName,java.lang.Class<{javax.xml.bind.JAXBElement%0}>,java.lang.Class,{javax.xml.bind.JAXBElement%0})
-cons public JAXBElement(javax.xml.namespace.QName,java.lang.Class<{javax.xml.bind.JAXBElement%0}>,{javax.xml.bind.JAXBElement%0})
+CLSS public jakarta.xml.bind.JAXBElement<%0 extends java.lang.Object>
+cons public JAXBElement(javax.xml.namespace.QName,java.lang.Class<{jakarta.xml.bind.JAXBElement%0}>,java.lang.Class,{jakarta.xml.bind.JAXBElement%0})
+cons public JAXBElement(javax.xml.namespace.QName,java.lang.Class<{jakarta.xml.bind.JAXBElement%0}>,{jakarta.xml.bind.JAXBElement%0})
 fld protected boolean nil
 fld protected final java.lang.Class scope
-fld protected final java.lang.Class<{javax.xml.bind.JAXBElement%0}> declaredType
+fld protected final java.lang.Class<{jakarta.xml.bind.JAXBElement%0}> declaredType
 fld protected final javax.xml.namespace.QName name
-fld protected {javax.xml.bind.JAXBElement%0} value
+fld protected {jakarta.xml.bind.JAXBElement%0} value
 innr public final static GlobalScope
 intf java.io.Serializable
 meth public boolean isGlobalScope()
 meth public boolean isNil()
 meth public boolean isTypeSubstituted()
 meth public java.lang.Class getScope()
-meth public java.lang.Class<{javax.xml.bind.JAXBElement%0}> getDeclaredType()
+meth public java.lang.Class<{jakarta.xml.bind.JAXBElement%0}> getDeclaredType()
 meth public javax.xml.namespace.QName getName()
 meth public void setNil(boolean)
-meth public void setValue({javax.xml.bind.JAXBElement%0})
-meth public {javax.xml.bind.JAXBElement%0} getValue()
+meth public void setValue({jakarta.xml.bind.JAXBElement%0})
+meth public {jakarta.xml.bind.JAXBElement%0} getValue()
 supr java.lang.Object
 hfds serialVersionUID
 
-CLSS public final static javax.xml.bind.JAXBElement$GlobalScope
+CLSS public final static jakarta.xml.bind.JAXBElement$GlobalScope
 cons public GlobalScope()
 supr java.lang.Object
 
-CLSS public javax.xml.bind.JAXBException
+CLSS public jakarta.xml.bind.JAXBException
 cons public JAXBException(java.lang.String)
 cons public JAXBException(java.lang.String,java.lang.String)
 cons public JAXBException(java.lang.String,java.lang.String,java.lang.Throwable)
@@ -347,86 +347,86 @@ meth public void setLinkedException(java.lang.Throwable)
 supr java.lang.Exception
 hfds errorCode,linkedException,serialVersionUID
 
-CLSS public abstract javax.xml.bind.JAXBIntrospector
+CLSS public abstract jakarta.xml.bind.JAXBIntrospector
 cons public JAXBIntrospector()
 meth public abstract boolean isElement(java.lang.Object)
 meth public abstract javax.xml.namespace.QName getElementName(java.lang.Object)
 meth public static java.lang.Object getValue(java.lang.Object)
 supr java.lang.Object
 
-CLSS public final javax.xml.bind.JAXBPermission
+CLSS public final jakarta.xml.bind.JAXBPermission
 cons public JAXBPermission(java.lang.String)
 supr java.security.BasicPermission
 hfds serialVersionUID
 
-CLSS public javax.xml.bind.MarshalException
+CLSS public jakarta.xml.bind.MarshalException
 cons public MarshalException(java.lang.String)
 cons public MarshalException(java.lang.String,java.lang.String)
 cons public MarshalException(java.lang.String,java.lang.String,java.lang.Throwable)
 cons public MarshalException(java.lang.String,java.lang.Throwable)
 cons public MarshalException(java.lang.Throwable)
-supr javax.xml.bind.JAXBException
+supr jakarta.xml.bind.JAXBException
 
-CLSS public abstract interface javax.xml.bind.Marshaller
+CLSS public abstract interface jakarta.xml.bind.Marshaller
 fld public final static java.lang.String JAXB_ENCODING = "jaxb.encoding"
 fld public final static java.lang.String JAXB_FORMATTED_OUTPUT = "jaxb.formatted.output"
 fld public final static java.lang.String JAXB_FRAGMENT = "jaxb.fragment"
 fld public final static java.lang.String JAXB_NO_NAMESPACE_SCHEMA_LOCATION = "jaxb.noNamespaceSchemaLocation"
 fld public final static java.lang.String JAXB_SCHEMA_LOCATION = "jaxb.schemaLocation"
 innr public abstract static Listener
-meth public abstract <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
-meth public abstract <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
-meth public abstract java.lang.Object getProperty(java.lang.String) throws javax.xml.bind.PropertyException
-meth public abstract javax.xml.bind.Marshaller$Listener getListener()
-meth public abstract javax.xml.bind.ValidationEventHandler getEventHandler() throws javax.xml.bind.JAXBException
-meth public abstract javax.xml.bind.attachment.AttachmentMarshaller getAttachmentMarshaller()
+meth public abstract <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
+meth public abstract <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
+meth public abstract java.lang.Object getProperty(java.lang.String) throws jakarta.xml.bind.PropertyException
+meth public abstract jakarta.xml.bind.Marshaller$Listener getListener()
+meth public abstract jakarta.xml.bind.ValidationEventHandler getEventHandler() throws jakarta.xml.bind.JAXBException
+meth public abstract jakarta.xml.bind.attachment.AttachmentMarshaller getAttachmentMarshaller()
 meth public abstract javax.xml.validation.Schema getSchema()
-meth public abstract org.w3c.dom.Node getNode(java.lang.Object) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,java.io.File) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,java.io.OutputStream) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,java.io.Writer) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,javax.xml.stream.XMLEventWriter) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,javax.xml.stream.XMLStreamWriter) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,javax.xml.transform.Result) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,org.w3c.dom.Node) throws javax.xml.bind.JAXBException
-meth public abstract void marshal(java.lang.Object,org.xml.sax.ContentHandler) throws javax.xml.bind.JAXBException
-meth public abstract void setAdapter(javax.xml.bind.annotation.adapters.XmlAdapter)
-meth public abstract void setAttachmentMarshaller(javax.xml.bind.attachment.AttachmentMarshaller)
-meth public abstract void setEventHandler(javax.xml.bind.ValidationEventHandler) throws javax.xml.bind.JAXBException
-meth public abstract void setListener(javax.xml.bind.Marshaller$Listener)
-meth public abstract void setProperty(java.lang.String,java.lang.Object) throws javax.xml.bind.PropertyException
+meth public abstract org.w3c.dom.Node getNode(java.lang.Object) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,java.io.File) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,java.io.OutputStream) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,java.io.Writer) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,javax.xml.stream.XMLEventWriter) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,javax.xml.stream.XMLStreamWriter) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,javax.xml.transform.Result) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,org.w3c.dom.Node) throws jakarta.xml.bind.JAXBException
+meth public abstract void marshal(java.lang.Object,org.xml.sax.ContentHandler) throws jakarta.xml.bind.JAXBException
+meth public abstract void setAdapter(jakarta.xml.bind.annotation.adapters.XmlAdapter)
+meth public abstract void setAttachmentMarshaller(jakarta.xml.bind.attachment.AttachmentMarshaller)
+meth public abstract void setEventHandler(jakarta.xml.bind.ValidationEventHandler) throws jakarta.xml.bind.JAXBException
+meth public abstract void setListener(jakarta.xml.bind.Marshaller$Listener)
+meth public abstract void setProperty(java.lang.String,java.lang.Object) throws jakarta.xml.bind.PropertyException
 meth public abstract void setSchema(javax.xml.validation.Schema)
 
-CLSS public abstract static javax.xml.bind.Marshaller$Listener
+CLSS public abstract static jakarta.xml.bind.Marshaller$Listener
 cons public Listener()
 meth public void afterMarshal(java.lang.Object)
 meth public void beforeMarshal(java.lang.Object)
 supr java.lang.Object
 
-CLSS public abstract interface javax.xml.bind.NotIdentifiableEvent
-intf javax.xml.bind.ValidationEvent
+CLSS public abstract interface jakarta.xml.bind.NotIdentifiableEvent
+intf jakarta.xml.bind.ValidationEvent
 
-CLSS public abstract interface javax.xml.bind.ParseConversionEvent
-intf javax.xml.bind.ValidationEvent
+CLSS public abstract interface jakarta.xml.bind.ParseConversionEvent
+intf jakarta.xml.bind.ValidationEvent
 
-CLSS public abstract interface javax.xml.bind.PrintConversionEvent
-intf javax.xml.bind.ValidationEvent
+CLSS public abstract interface jakarta.xml.bind.PrintConversionEvent
+intf jakarta.xml.bind.ValidationEvent
 
-CLSS public javax.xml.bind.PropertyException
+CLSS public jakarta.xml.bind.PropertyException
 cons public PropertyException(java.lang.String)
 cons public PropertyException(java.lang.String,java.lang.Object)
 cons public PropertyException(java.lang.String,java.lang.String)
 cons public PropertyException(java.lang.String,java.lang.String,java.lang.Throwable)
 cons public PropertyException(java.lang.String,java.lang.Throwable)
 cons public PropertyException(java.lang.Throwable)
-supr javax.xml.bind.JAXBException
+supr jakarta.xml.bind.JAXBException
 
-CLSS public abstract javax.xml.bind.SchemaOutputResolver
+CLSS public abstract jakarta.xml.bind.SchemaOutputResolver
 cons public SchemaOutputResolver()
 meth public abstract javax.xml.transform.Result createOutput(java.lang.String,java.lang.String) throws java.io.IOException
 supr java.lang.Object
 
-CLSS public javax.xml.bind.TypeConstraintException
+CLSS public jakarta.xml.bind.TypeConstraintException
 cons public TypeConstraintException(java.lang.String)
 cons public TypeConstraintException(java.lang.String,java.lang.String)
 cons public TypeConstraintException(java.lang.String,java.lang.String,java.lang.Throwable)
@@ -441,69 +441,69 @@ meth public void setLinkedException(java.lang.Throwable)
 supr java.lang.RuntimeException
 hfds errorCode,linkedException
 
-CLSS public javax.xml.bind.UnmarshalException
+CLSS public jakarta.xml.bind.UnmarshalException
 cons public UnmarshalException(java.lang.String)
 cons public UnmarshalException(java.lang.String,java.lang.String)
 cons public UnmarshalException(java.lang.String,java.lang.String,java.lang.Throwable)
 cons public UnmarshalException(java.lang.String,java.lang.Throwable)
 cons public UnmarshalException(java.lang.Throwable)
-supr javax.xml.bind.JAXBException
+supr jakarta.xml.bind.JAXBException
 
-CLSS public abstract interface javax.xml.bind.Unmarshaller
+CLSS public abstract interface jakarta.xml.bind.Unmarshaller
 innr public abstract static Listener
-meth public abstract <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLEventReader,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public abstract <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLStreamReader,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public abstract <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.transform.Source,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public abstract <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(org.w3c.dom.Node,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public abstract <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
-meth public abstract <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
-meth public abstract boolean isValidating() throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object getProperty(java.lang.String) throws javax.xml.bind.PropertyException
-meth public abstract java.lang.Object unmarshal(java.io.File) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(java.io.InputStream) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(java.io.Reader) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(java.net.URL) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(javax.xml.stream.XMLEventReader) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(javax.xml.stream.XMLStreamReader) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(javax.xml.transform.Source) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(org.w3c.dom.Node) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object unmarshal(org.xml.sax.InputSource) throws javax.xml.bind.JAXBException
-meth public abstract javax.xml.bind.Unmarshaller$Listener getListener()
-meth public abstract javax.xml.bind.UnmarshallerHandler getUnmarshallerHandler()
-meth public abstract javax.xml.bind.ValidationEventHandler getEventHandler() throws javax.xml.bind.JAXBException
-meth public abstract javax.xml.bind.attachment.AttachmentUnmarshaller getAttachmentUnmarshaller()
+meth public abstract <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLEventReader,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public abstract <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLStreamReader,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public abstract <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.transform.Source,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public abstract <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(org.w3c.dom.Node,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public abstract <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
+meth public abstract <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
+meth public abstract boolean isValidating() throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object getProperty(java.lang.String) throws jakarta.xml.bind.PropertyException
+meth public abstract java.lang.Object unmarshal(java.io.File) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(java.io.InputStream) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(java.io.Reader) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(java.net.URL) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(javax.xml.stream.XMLEventReader) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(javax.xml.stream.XMLStreamReader) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(javax.xml.transform.Source) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(org.w3c.dom.Node) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object unmarshal(org.xml.sax.InputSource) throws jakarta.xml.bind.JAXBException
+meth public abstract jakarta.xml.bind.Unmarshaller$Listener getListener()
+meth public abstract jakarta.xml.bind.UnmarshallerHandler getUnmarshallerHandler()
+meth public abstract jakarta.xml.bind.ValidationEventHandler getEventHandler() throws jakarta.xml.bind.JAXBException
+meth public abstract jakarta.xml.bind.attachment.AttachmentUnmarshaller getAttachmentUnmarshaller()
 meth public abstract javax.xml.validation.Schema getSchema()
-meth public abstract void setAdapter(javax.xml.bind.annotation.adapters.XmlAdapter)
-meth public abstract void setAttachmentUnmarshaller(javax.xml.bind.attachment.AttachmentUnmarshaller)
-meth public abstract void setEventHandler(javax.xml.bind.ValidationEventHandler) throws javax.xml.bind.JAXBException
-meth public abstract void setListener(javax.xml.bind.Unmarshaller$Listener)
-meth public abstract void setProperty(java.lang.String,java.lang.Object) throws javax.xml.bind.PropertyException
+meth public abstract void setAdapter(jakarta.xml.bind.annotation.adapters.XmlAdapter)
+meth public abstract void setAttachmentUnmarshaller(jakarta.xml.bind.attachment.AttachmentUnmarshaller)
+meth public abstract void setEventHandler(jakarta.xml.bind.ValidationEventHandler) throws jakarta.xml.bind.JAXBException
+meth public abstract void setListener(jakarta.xml.bind.Unmarshaller$Listener)
+meth public abstract void setProperty(java.lang.String,java.lang.Object) throws jakarta.xml.bind.PropertyException
 meth public abstract void setSchema(javax.xml.validation.Schema)
-meth public abstract void setValidating(boolean) throws javax.xml.bind.JAXBException
+meth public abstract void setValidating(boolean) throws jakarta.xml.bind.JAXBException
 
-CLSS public abstract static javax.xml.bind.Unmarshaller$Listener
+CLSS public abstract static jakarta.xml.bind.Unmarshaller$Listener
 cons public Listener()
 meth public void afterUnmarshal(java.lang.Object,java.lang.Object)
 meth public void beforeUnmarshal(java.lang.Object,java.lang.Object)
 supr java.lang.Object
 
-CLSS public abstract interface javax.xml.bind.UnmarshallerHandler
+CLSS public abstract interface jakarta.xml.bind.UnmarshallerHandler
 intf org.xml.sax.ContentHandler
-meth public abstract java.lang.Object getResult() throws javax.xml.bind.JAXBException
+meth public abstract java.lang.Object getResult() throws jakarta.xml.bind.JAXBException
 
-CLSS public abstract interface javax.xml.bind.ValidationEvent
+CLSS public abstract interface jakarta.xml.bind.ValidationEvent
 fld public final static int ERROR = 1
 fld public final static int FATAL_ERROR = 2
 fld public final static int WARNING = 0
 meth public abstract int getSeverity()
 meth public abstract java.lang.String getMessage()
 meth public abstract java.lang.Throwable getLinkedException()
-meth public abstract javax.xml.bind.ValidationEventLocator getLocator()
+meth public abstract jakarta.xml.bind.ValidationEventLocator getLocator()
 
-CLSS public abstract interface javax.xml.bind.ValidationEventHandler
-meth public abstract boolean handleEvent(javax.xml.bind.ValidationEvent)
+CLSS public abstract interface jakarta.xml.bind.ValidationEventHandler
+meth public abstract boolean handleEvent(jakarta.xml.bind.ValidationEvent)
 
-CLSS public abstract interface javax.xml.bind.ValidationEventLocator
+CLSS public abstract interface jakarta.xml.bind.ValidationEventLocator
 meth public abstract int getColumnNumber()
 meth public abstract int getLineNumber()
 meth public abstract int getOffset()
@@ -511,87 +511,87 @@ meth public abstract java.lang.Object getObject()
 meth public abstract java.net.URL getURL()
 meth public abstract org.w3c.dom.Node getNode()
 
-CLSS public javax.xml.bind.ValidationException
+CLSS public jakarta.xml.bind.ValidationException
 cons public ValidationException(java.lang.String)
 cons public ValidationException(java.lang.String,java.lang.String)
 cons public ValidationException(java.lang.String,java.lang.String,java.lang.Throwable)
 cons public ValidationException(java.lang.String,java.lang.Throwable)
 cons public ValidationException(java.lang.Throwable)
-supr javax.xml.bind.JAXBException
+supr jakarta.xml.bind.JAXBException
 
-CLSS public abstract interface javax.xml.bind.Validator
-meth public abstract boolean validate(java.lang.Object) throws javax.xml.bind.JAXBException
-meth public abstract boolean validateRoot(java.lang.Object) throws javax.xml.bind.JAXBException
-meth public abstract java.lang.Object getProperty(java.lang.String) throws javax.xml.bind.PropertyException
-meth public abstract javax.xml.bind.ValidationEventHandler getEventHandler() throws javax.xml.bind.JAXBException
-meth public abstract void setEventHandler(javax.xml.bind.ValidationEventHandler) throws javax.xml.bind.JAXBException
-meth public abstract void setProperty(java.lang.String,java.lang.Object) throws javax.xml.bind.PropertyException
+CLSS public abstract interface jakarta.xml.bind.Validator
+meth public abstract boolean validate(java.lang.Object) throws jakarta.xml.bind.JAXBException
+meth public abstract boolean validateRoot(java.lang.Object) throws jakarta.xml.bind.JAXBException
+meth public abstract java.lang.Object getProperty(java.lang.String) throws jakarta.xml.bind.PropertyException
+meth public abstract jakarta.xml.bind.ValidationEventHandler getEventHandler() throws jakarta.xml.bind.JAXBException
+meth public abstract void setEventHandler(jakarta.xml.bind.ValidationEventHandler) throws jakarta.xml.bind.JAXBException
+meth public abstract void setProperty(java.lang.String,java.lang.Object) throws jakarta.xml.bind.PropertyException
 
-CLSS public abstract interface javax.xml.bind.annotation.DomHandler<%0 extends java.lang.Object, %1 extends javax.xml.transform.Result>
-meth public abstract javax.xml.transform.Source marshal({javax.xml.bind.annotation.DomHandler%0},javax.xml.bind.ValidationEventHandler)
-meth public abstract {javax.xml.bind.annotation.DomHandler%0} getElement({javax.xml.bind.annotation.DomHandler%1})
-meth public abstract {javax.xml.bind.annotation.DomHandler%1} createUnmarshaller(javax.xml.bind.ValidationEventHandler)
+CLSS public abstract interface jakarta.xml.bind.annotation.DomHandler<%0 extends java.lang.Object, %1 extends javax.xml.transform.Result>
+meth public abstract javax.xml.transform.Source marshal({jakarta.xml.bind.annotation.DomHandler%0},jakarta.xml.bind.ValidationEventHandler)
+meth public abstract {jakarta.xml.bind.annotation.DomHandler%0} getElement({jakarta.xml.bind.annotation.DomHandler%1})
+meth public abstract {jakarta.xml.bind.annotation.DomHandler%1} createUnmarshaller(jakarta.xml.bind.ValidationEventHandler)
 
-CLSS public javax.xml.bind.annotation.W3CDomHandler
+CLSS public jakarta.xml.bind.annotation.W3CDomHandler
 cons public W3CDomHandler()
 cons public W3CDomHandler(javax.xml.parsers.DocumentBuilder)
-intf javax.xml.bind.annotation.DomHandler<org.w3c.dom.Element,javax.xml.transform.dom.DOMResult>
+intf jakarta.xml.bind.annotation.DomHandler<org.w3c.dom.Element,javax.xml.transform.dom.DOMResult>
 meth public javax.xml.parsers.DocumentBuilder getBuilder()
-meth public javax.xml.transform.Source marshal(org.w3c.dom.Element,javax.xml.bind.ValidationEventHandler)
-meth public javax.xml.transform.dom.DOMResult createUnmarshaller(javax.xml.bind.ValidationEventHandler)
+meth public javax.xml.transform.Source marshal(org.w3c.dom.Element,jakarta.xml.bind.ValidationEventHandler)
+meth public javax.xml.transform.dom.DOMResult createUnmarshaller(jakarta.xml.bind.ValidationEventHandler)
 meth public org.w3c.dom.Element getElement(javax.xml.transform.dom.DOMResult)
 meth public void setBuilder(javax.xml.parsers.DocumentBuilder)
 supr java.lang.Object
 hfds builder
 
-CLSS public final !enum javax.xml.bind.annotation.XmlAccessOrder
-fld public final static javax.xml.bind.annotation.XmlAccessOrder ALPHABETICAL
-fld public final static javax.xml.bind.annotation.XmlAccessOrder UNDEFINED
-meth public final static javax.xml.bind.annotation.XmlAccessOrder[] values()
-meth public static javax.xml.bind.annotation.XmlAccessOrder valueOf(java.lang.String)
-supr java.lang.Enum<javax.xml.bind.annotation.XmlAccessOrder>
+CLSS public final !enum jakarta.xml.bind.annotation.XmlAccessOrder
+fld public final static jakarta.xml.bind.annotation.XmlAccessOrder ALPHABETICAL
+fld public final static jakarta.xml.bind.annotation.XmlAccessOrder UNDEFINED
+meth public final static jakarta.xml.bind.annotation.XmlAccessOrder[] values()
+meth public static jakarta.xml.bind.annotation.XmlAccessOrder valueOf(java.lang.String)
+supr java.lang.Enum<jakarta.xml.bind.annotation.XmlAccessOrder>
 
-CLSS public final !enum javax.xml.bind.annotation.XmlAccessType
-fld public final static javax.xml.bind.annotation.XmlAccessType FIELD
-fld public final static javax.xml.bind.annotation.XmlAccessType NONE
-fld public final static javax.xml.bind.annotation.XmlAccessType PROPERTY
-fld public final static javax.xml.bind.annotation.XmlAccessType PUBLIC_MEMBER
-meth public final static javax.xml.bind.annotation.XmlAccessType[] values()
-meth public static javax.xml.bind.annotation.XmlAccessType valueOf(java.lang.String)
-supr java.lang.Enum<javax.xml.bind.annotation.XmlAccessType>
+CLSS public final !enum jakarta.xml.bind.annotation.XmlAccessType
+fld public final static jakarta.xml.bind.annotation.XmlAccessType FIELD
+fld public final static jakarta.xml.bind.annotation.XmlAccessType NONE
+fld public final static jakarta.xml.bind.annotation.XmlAccessType PROPERTY
+fld public final static jakarta.xml.bind.annotation.XmlAccessType PUBLIC_MEMBER
+meth public final static jakarta.xml.bind.annotation.XmlAccessType[] values()
+meth public static jakarta.xml.bind.annotation.XmlAccessType valueOf(java.lang.String)
+supr java.lang.Enum<jakarta.xml.bind.annotation.XmlAccessType>
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlAccessorOrder
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlAccessorOrder
  anno 0 java.lang.annotation.Inherited()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PACKAGE, TYPE])
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault javax.xml.bind.annotation.XmlAccessOrder value()
+meth public abstract !hasdefault jakarta.xml.bind.annotation.XmlAccessOrder value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlAccessorType
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlAccessorType
  anno 0 java.lang.annotation.Inherited()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PACKAGE, TYPE])
 intf java.lang.annotation.Annotation
-meth public abstract !hasdefault javax.xml.bind.annotation.XmlAccessType value()
+meth public abstract !hasdefault jakarta.xml.bind.annotation.XmlAccessType value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlAnyAttribute
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlAnyAttribute
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlAnyElement
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlAnyElement
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault boolean lax()
-meth public abstract !hasdefault java.lang.Class<? extends javax.xml.bind.annotation.DomHandler> value()
+meth public abstract !hasdefault java.lang.Class<? extends jakarta.xml.bind.annotation.DomHandler> value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlAttachmentRef
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlAttachmentRef
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD, PARAMETER])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlAttribute
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlAttribute
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
@@ -599,7 +599,7 @@ meth public abstract !hasdefault boolean required()
 meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String namespace()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlElement
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlElement
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD, PARAMETER])
 innr public final static DEFAULT
@@ -611,11 +611,11 @@ meth public abstract !hasdefault java.lang.String defaultValue()
 meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String namespace()
 
-CLSS public final static javax.xml.bind.annotation.XmlElement$DEFAULT
+CLSS public final static jakarta.xml.bind.annotation.XmlElement$DEFAULT
 cons public DEFAULT()
 supr java.lang.Object
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlElementDecl
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlElementDecl
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[METHOD])
 innr public final static GLOBAL
@@ -627,11 +627,11 @@ meth public abstract !hasdefault java.lang.String substitutionHeadName()
 meth public abstract !hasdefault java.lang.String substitutionHeadNamespace()
 meth public abstract java.lang.String name()
 
-CLSS public final static javax.xml.bind.annotation.XmlElementDecl$GLOBAL
+CLSS public final static jakarta.xml.bind.annotation.XmlElementDecl$GLOBAL
 cons public GLOBAL()
 supr java.lang.Object
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlElementRef
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlElementRef
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 innr public final static DEFAULT
@@ -641,17 +641,17 @@ meth public abstract !hasdefault java.lang.Class type()
 meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String namespace()
 
-CLSS public final static javax.xml.bind.annotation.XmlElementRef$DEFAULT
+CLSS public final static jakarta.xml.bind.annotation.XmlElementRef$DEFAULT
 cons public DEFAULT()
 supr java.lang.Object
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlElementRefs
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlElementRefs
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
-meth public abstract javax.xml.bind.annotation.XmlElementRef[] value()
+meth public abstract jakarta.xml.bind.annotation.XmlElementRef[] value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlElementWrapper
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlElementWrapper
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
@@ -660,94 +660,94 @@ meth public abstract !hasdefault boolean required()
 meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String namespace()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlElements
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlElements
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
-meth public abstract javax.xml.bind.annotation.XmlElement[] value()
+meth public abstract jakarta.xml.bind.annotation.XmlElement[] value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlEnum
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlEnum
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.Class<?> value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlEnumValue
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlEnumValue
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.String value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlID
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlID
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlIDREF
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlIDREF
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlInlineBinaryData
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlInlineBinaryData
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD, TYPE])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlList
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlList
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD, PARAMETER])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlMimeType
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlMimeType
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD, PARAMETER])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.String value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlMixed
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlMixed
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlNs
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlNs
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.String namespaceURI()
 meth public abstract java.lang.String prefix()
 
-CLSS public final !enum javax.xml.bind.annotation.XmlNsForm
-fld public final static javax.xml.bind.annotation.XmlNsForm QUALIFIED
-fld public final static javax.xml.bind.annotation.XmlNsForm UNQUALIFIED
-fld public final static javax.xml.bind.annotation.XmlNsForm UNSET
-meth public final static javax.xml.bind.annotation.XmlNsForm[] values()
-meth public static javax.xml.bind.annotation.XmlNsForm valueOf(java.lang.String)
-supr java.lang.Enum<javax.xml.bind.annotation.XmlNsForm>
+CLSS public final !enum jakarta.xml.bind.annotation.XmlNsForm
+fld public final static jakarta.xml.bind.annotation.XmlNsForm QUALIFIED
+fld public final static jakarta.xml.bind.annotation.XmlNsForm UNQUALIFIED
+fld public final static jakarta.xml.bind.annotation.XmlNsForm UNSET
+meth public final static jakarta.xml.bind.annotation.XmlNsForm[] values()
+meth public static jakarta.xml.bind.annotation.XmlNsForm valueOf(java.lang.String)
+supr java.lang.Enum<jakarta.xml.bind.annotation.XmlNsForm>
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlRegistry
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlRegistry
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlRootElement
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlRootElement
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String namespace()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlSchema
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlSchema
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PACKAGE])
 fld public final static java.lang.String NO_LOCATION = "##generate"
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.String location()
 meth public abstract !hasdefault java.lang.String namespace()
-meth public abstract !hasdefault javax.xml.bind.annotation.XmlNsForm attributeFormDefault()
-meth public abstract !hasdefault javax.xml.bind.annotation.XmlNsForm elementFormDefault()
-meth public abstract !hasdefault javax.xml.bind.annotation.XmlNs[] xmlns()
+meth public abstract !hasdefault jakarta.xml.bind.annotation.XmlNsForm attributeFormDefault()
+meth public abstract !hasdefault jakarta.xml.bind.annotation.XmlNsForm elementFormDefault()
+meth public abstract !hasdefault jakarta.xml.bind.annotation.XmlNs[] xmlns()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlSchemaType
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlSchemaType
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD, PACKAGE])
 innr public final static DEFAULT
@@ -756,28 +756,28 @@ meth public abstract !hasdefault java.lang.Class type()
 meth public abstract !hasdefault java.lang.String namespace()
 meth public abstract java.lang.String name()
 
-CLSS public final static javax.xml.bind.annotation.XmlSchemaType$DEFAULT
+CLSS public final static jakarta.xml.bind.annotation.XmlSchemaType$DEFAULT
 cons public DEFAULT()
 supr java.lang.Object
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlSchemaTypes
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlSchemaTypes
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PACKAGE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.xml.bind.annotation.XmlSchemaType[] value()
+meth public abstract jakarta.xml.bind.annotation.XmlSchemaType[] value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlSeeAlso
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlSeeAlso
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.Class[] value()
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlTransient
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlTransient
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD, TYPE])
 intf java.lang.annotation.Annotation
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlType
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlType
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 innr public final static DEFAULT
@@ -788,77 +788,77 @@ meth public abstract !hasdefault java.lang.String name()
 meth public abstract !hasdefault java.lang.String namespace()
 meth public abstract !hasdefault java.lang.String[] propOrder()
 
-CLSS public final static javax.xml.bind.annotation.XmlType$DEFAULT
+CLSS public final static jakarta.xml.bind.annotation.XmlType$DEFAULT
 cons public DEFAULT()
 supr java.lang.Object
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.XmlValue
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.XmlValue
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[FIELD, METHOD])
 intf java.lang.annotation.Annotation
 
-CLSS public javax.xml.bind.annotation.adapters.CollapsedStringAdapter
+CLSS public jakarta.xml.bind.annotation.adapters.CollapsedStringAdapter
 cons public CollapsedStringAdapter()
 meth protected static boolean isWhiteSpace(char)
 meth public java.lang.String marshal(java.lang.String)
 meth public java.lang.String unmarshal(java.lang.String)
-supr javax.xml.bind.annotation.adapters.XmlAdapter<java.lang.String,java.lang.String>
+supr jakarta.xml.bind.annotation.adapters.XmlAdapter<java.lang.String,java.lang.String>
 
-CLSS public final javax.xml.bind.annotation.adapters.HexBinaryAdapter
+CLSS public final jakarta.xml.bind.annotation.adapters.HexBinaryAdapter
 cons public HexBinaryAdapter()
 meth public byte[] unmarshal(java.lang.String)
 meth public java.lang.String marshal(byte[])
-supr javax.xml.bind.annotation.adapters.XmlAdapter<java.lang.String,byte[]>
+supr jakarta.xml.bind.annotation.adapters.XmlAdapter<java.lang.String,byte[]>
 
-CLSS public final javax.xml.bind.annotation.adapters.NormalizedStringAdapter
+CLSS public final jakarta.xml.bind.annotation.adapters.NormalizedStringAdapter
 cons public NormalizedStringAdapter()
 meth protected static boolean isWhiteSpaceExceptSpace(char)
 meth public java.lang.String marshal(java.lang.String)
 meth public java.lang.String unmarshal(java.lang.String)
-supr javax.xml.bind.annotation.adapters.XmlAdapter<java.lang.String,java.lang.String>
+supr jakarta.xml.bind.annotation.adapters.XmlAdapter<java.lang.String,java.lang.String>
 
-CLSS public abstract javax.xml.bind.annotation.adapters.XmlAdapter<%0 extends java.lang.Object, %1 extends java.lang.Object>
+CLSS public abstract jakarta.xml.bind.annotation.adapters.XmlAdapter<%0 extends java.lang.Object, %1 extends java.lang.Object>
 cons protected XmlAdapter()
-meth public abstract {javax.xml.bind.annotation.adapters.XmlAdapter%0} marshal({javax.xml.bind.annotation.adapters.XmlAdapter%1}) throws java.lang.Exception
-meth public abstract {javax.xml.bind.annotation.adapters.XmlAdapter%1} unmarshal({javax.xml.bind.annotation.adapters.XmlAdapter%0}) throws java.lang.Exception
+meth public abstract {jakarta.xml.bind.annotation.adapters.XmlAdapter%0} marshal({jakarta.xml.bind.annotation.adapters.XmlAdapter%1}) throws java.lang.Exception
+meth public abstract {jakarta.xml.bind.annotation.adapters.XmlAdapter%1} unmarshal({jakarta.xml.bind.annotation.adapters.XmlAdapter%0}) throws java.lang.Exception
 supr java.lang.Object
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PACKAGE, FIELD, METHOD, TYPE, PARAMETER])
 innr public final static DEFAULT
 intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.Class type()
-meth public abstract java.lang.Class<? extends javax.xml.bind.annotation.adapters.XmlAdapter> value()
+meth public abstract java.lang.Class<? extends jakarta.xml.bind.annotation.adapters.XmlAdapter> value()
 
-CLSS public final static javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter$DEFAULT
+CLSS public final static jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter$DEFAULT
 cons public DEFAULT()
 supr java.lang.Object
 
-CLSS public abstract interface !annotation javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters
+CLSS public abstract interface !annotation jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapters
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[PACKAGE])
 intf java.lang.annotation.Annotation
-meth public abstract javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter[] value()
+meth public abstract jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter[] value()
 
-CLSS public abstract javax.xml.bind.attachment.AttachmentMarshaller
+CLSS public abstract jakarta.xml.bind.attachment.AttachmentMarshaller
 cons public AttachmentMarshaller()
 meth public abstract java.lang.String addMtomAttachment(byte[],int,int,java.lang.String,java.lang.String,java.lang.String)
-meth public abstract java.lang.String addMtomAttachment(javax.activation.DataHandler,java.lang.String,java.lang.String)
-meth public abstract java.lang.String addSwaRefAttachment(javax.activation.DataHandler)
+meth public abstract java.lang.String addMtomAttachment(jakarta.activation.DataHandler,java.lang.String,java.lang.String)
+meth public abstract java.lang.String addSwaRefAttachment(jakarta.activation.DataHandler)
 meth public boolean isXOPPackage()
 supr java.lang.Object
 
-CLSS public abstract javax.xml.bind.attachment.AttachmentUnmarshaller
+CLSS public abstract jakarta.xml.bind.attachment.AttachmentUnmarshaller
 cons public AttachmentUnmarshaller()
 meth public abstract byte[] getAttachmentAsByteArray(java.lang.String)
-meth public abstract javax.activation.DataHandler getAttachmentAsDataHandler(java.lang.String)
+meth public abstract jakarta.activation.DataHandler getAttachmentAsDataHandler(java.lang.String)
 meth public boolean isXOPPackage()
 supr java.lang.Object
 
-CLSS public abstract javax.xml.bind.helpers.AbstractMarshallerImpl
+CLSS public abstract jakarta.xml.bind.helpers.AbstractMarshallerImpl
 cons public AbstractMarshallerImpl()
-intf javax.xml.bind.Marshaller
+intf jakarta.xml.bind.Marshaller
 meth protected boolean isFormattedOutput()
 meth protected boolean isFragment()
 meth protected java.lang.String getEncoding()
@@ -870,114 +870,114 @@ meth protected void setFormattedOutput(boolean)
 meth protected void setFragment(boolean)
 meth protected void setNoNSSchemaLocation(java.lang.String)
 meth protected void setSchemaLocation(java.lang.String)
-meth public <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
-meth public <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
-meth public final void marshal(java.lang.Object,java.io.OutputStream) throws javax.xml.bind.JAXBException
-meth public final void marshal(java.lang.Object,java.io.Writer) throws javax.xml.bind.JAXBException
-meth public final void marshal(java.lang.Object,org.w3c.dom.Node) throws javax.xml.bind.JAXBException
-meth public final void marshal(java.lang.Object,org.xml.sax.ContentHandler) throws javax.xml.bind.JAXBException
-meth public java.lang.Object getProperty(java.lang.String) throws javax.xml.bind.PropertyException
-meth public javax.xml.bind.Marshaller$Listener getListener()
-meth public javax.xml.bind.ValidationEventHandler getEventHandler() throws javax.xml.bind.JAXBException
-meth public javax.xml.bind.attachment.AttachmentMarshaller getAttachmentMarshaller()
+meth public <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
+meth public <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
+meth public final void marshal(java.lang.Object,java.io.OutputStream) throws jakarta.xml.bind.JAXBException
+meth public final void marshal(java.lang.Object,java.io.Writer) throws jakarta.xml.bind.JAXBException
+meth public final void marshal(java.lang.Object,org.w3c.dom.Node) throws jakarta.xml.bind.JAXBException
+meth public final void marshal(java.lang.Object,org.xml.sax.ContentHandler) throws jakarta.xml.bind.JAXBException
+meth public java.lang.Object getProperty(java.lang.String) throws jakarta.xml.bind.PropertyException
+meth public jakarta.xml.bind.Marshaller$Listener getListener()
+meth public jakarta.xml.bind.ValidationEventHandler getEventHandler() throws jakarta.xml.bind.JAXBException
+meth public jakarta.xml.bind.attachment.AttachmentMarshaller getAttachmentMarshaller()
 meth public javax.xml.validation.Schema getSchema()
-meth public org.w3c.dom.Node getNode(java.lang.Object) throws javax.xml.bind.JAXBException
-meth public void marshal(java.lang.Object,java.io.File) throws javax.xml.bind.JAXBException
-meth public void marshal(java.lang.Object,javax.xml.stream.XMLEventWriter) throws javax.xml.bind.JAXBException
-meth public void marshal(java.lang.Object,javax.xml.stream.XMLStreamWriter) throws javax.xml.bind.JAXBException
-meth public void setAdapter(javax.xml.bind.annotation.adapters.XmlAdapter)
-meth public void setAttachmentMarshaller(javax.xml.bind.attachment.AttachmentMarshaller)
-meth public void setEventHandler(javax.xml.bind.ValidationEventHandler) throws javax.xml.bind.JAXBException
-meth public void setListener(javax.xml.bind.Marshaller$Listener)
-meth public void setProperty(java.lang.String,java.lang.Object) throws javax.xml.bind.PropertyException
+meth public org.w3c.dom.Node getNode(java.lang.Object) throws jakarta.xml.bind.JAXBException
+meth public void marshal(java.lang.Object,java.io.File) throws jakarta.xml.bind.JAXBException
+meth public void marshal(java.lang.Object,javax.xml.stream.XMLEventWriter) throws jakarta.xml.bind.JAXBException
+meth public void marshal(java.lang.Object,javax.xml.stream.XMLStreamWriter) throws jakarta.xml.bind.JAXBException
+meth public void setAdapter(jakarta.xml.bind.annotation.adapters.XmlAdapter)
+meth public void setAttachmentMarshaller(jakarta.xml.bind.attachment.AttachmentMarshaller)
+meth public void setEventHandler(jakarta.xml.bind.ValidationEventHandler) throws jakarta.xml.bind.JAXBException
+meth public void setListener(jakarta.xml.bind.Marshaller$Listener)
+meth public void setProperty(java.lang.String,java.lang.Object) throws jakarta.xml.bind.PropertyException
 meth public void setSchema(javax.xml.validation.Schema)
 supr java.lang.Object
 hfds aliases,encoding,eventHandler,formattedOutput,fragment,noNSSchemaLocation,schemaLocation
 
-CLSS public abstract javax.xml.bind.helpers.AbstractUnmarshallerImpl
+CLSS public abstract jakarta.xml.bind.helpers.AbstractUnmarshallerImpl
 cons public AbstractUnmarshallerImpl()
 fld protected boolean validating
-intf javax.xml.bind.Unmarshaller
-meth protected abstract java.lang.Object unmarshal(org.xml.sax.XMLReader,org.xml.sax.InputSource) throws javax.xml.bind.JAXBException
-meth protected javax.xml.bind.UnmarshalException createUnmarshalException(org.xml.sax.SAXException)
-meth protected org.xml.sax.XMLReader getXMLReader() throws javax.xml.bind.JAXBException
-meth public <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLEventReader,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLStreamReader,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.transform.Source,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public <%0 extends java.lang.Object> javax.xml.bind.JAXBElement<{%%0}> unmarshal(org.w3c.dom.Node,java.lang.Class<{%%0}>) throws javax.xml.bind.JAXBException
-meth public <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
-meth public <%0 extends javax.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
-meth public boolean isValidating() throws javax.xml.bind.JAXBException
-meth public final java.lang.Object unmarshal(java.io.File) throws javax.xml.bind.JAXBException
-meth public final java.lang.Object unmarshal(java.io.InputStream) throws javax.xml.bind.JAXBException
-meth public final java.lang.Object unmarshal(java.io.Reader) throws javax.xml.bind.JAXBException
-meth public final java.lang.Object unmarshal(java.net.URL) throws javax.xml.bind.JAXBException
-meth public final java.lang.Object unmarshal(org.xml.sax.InputSource) throws javax.xml.bind.JAXBException
-meth public java.lang.Object getProperty(java.lang.String) throws javax.xml.bind.PropertyException
-meth public java.lang.Object unmarshal(javax.xml.stream.XMLEventReader) throws javax.xml.bind.JAXBException
-meth public java.lang.Object unmarshal(javax.xml.stream.XMLStreamReader) throws javax.xml.bind.JAXBException
-meth public java.lang.Object unmarshal(javax.xml.transform.Source) throws javax.xml.bind.JAXBException
-meth public javax.xml.bind.Unmarshaller$Listener getListener()
-meth public javax.xml.bind.ValidationEventHandler getEventHandler() throws javax.xml.bind.JAXBException
-meth public javax.xml.bind.attachment.AttachmentUnmarshaller getAttachmentUnmarshaller()
+intf jakarta.xml.bind.Unmarshaller
+meth protected abstract java.lang.Object unmarshal(org.xml.sax.XMLReader,org.xml.sax.InputSource) throws jakarta.xml.bind.JAXBException
+meth protected jakarta.xml.bind.UnmarshalException createUnmarshalException(org.xml.sax.SAXException)
+meth protected org.xml.sax.XMLReader getXMLReader() throws jakarta.xml.bind.JAXBException
+meth public <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLEventReader,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.stream.XMLStreamReader,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(javax.xml.transform.Source,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public <%0 extends java.lang.Object> jakarta.xml.bind.JAXBElement<{%%0}> unmarshal(org.w3c.dom.Node,java.lang.Class<{%%0}>) throws jakarta.xml.bind.JAXBException
+meth public <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> void setAdapter(java.lang.Class<{%%0}>,{%%0})
+meth public <%0 extends jakarta.xml.bind.annotation.adapters.XmlAdapter> {%%0} getAdapter(java.lang.Class<{%%0}>)
+meth public boolean isValidating() throws jakarta.xml.bind.JAXBException
+meth public final java.lang.Object unmarshal(java.io.File) throws jakarta.xml.bind.JAXBException
+meth public final java.lang.Object unmarshal(java.io.InputStream) throws jakarta.xml.bind.JAXBException
+meth public final java.lang.Object unmarshal(java.io.Reader) throws jakarta.xml.bind.JAXBException
+meth public final java.lang.Object unmarshal(java.net.URL) throws jakarta.xml.bind.JAXBException
+meth public final java.lang.Object unmarshal(org.xml.sax.InputSource) throws jakarta.xml.bind.JAXBException
+meth public java.lang.Object getProperty(java.lang.String) throws jakarta.xml.bind.PropertyException
+meth public java.lang.Object unmarshal(javax.xml.stream.XMLEventReader) throws jakarta.xml.bind.JAXBException
+meth public java.lang.Object unmarshal(javax.xml.stream.XMLStreamReader) throws jakarta.xml.bind.JAXBException
+meth public java.lang.Object unmarshal(javax.xml.transform.Source) throws jakarta.xml.bind.JAXBException
+meth public jakarta.xml.bind.Unmarshaller$Listener getListener()
+meth public jakarta.xml.bind.ValidationEventHandler getEventHandler() throws jakarta.xml.bind.JAXBException
+meth public jakarta.xml.bind.attachment.AttachmentUnmarshaller getAttachmentUnmarshaller()
 meth public javax.xml.validation.Schema getSchema()
-meth public void setAdapter(javax.xml.bind.annotation.adapters.XmlAdapter)
-meth public void setAttachmentUnmarshaller(javax.xml.bind.attachment.AttachmentUnmarshaller)
-meth public void setEventHandler(javax.xml.bind.ValidationEventHandler) throws javax.xml.bind.JAXBException
-meth public void setListener(javax.xml.bind.Unmarshaller$Listener)
-meth public void setProperty(java.lang.String,java.lang.Object) throws javax.xml.bind.PropertyException
+meth public void setAdapter(jakarta.xml.bind.annotation.adapters.XmlAdapter)
+meth public void setAttachmentUnmarshaller(jakarta.xml.bind.attachment.AttachmentUnmarshaller)
+meth public void setEventHandler(jakarta.xml.bind.ValidationEventHandler) throws jakarta.xml.bind.JAXBException
+meth public void setListener(jakarta.xml.bind.Unmarshaller$Listener)
+meth public void setProperty(java.lang.String,java.lang.Object) throws jakarta.xml.bind.PropertyException
 meth public void setSchema(javax.xml.validation.Schema)
-meth public void setValidating(boolean) throws javax.xml.bind.JAXBException
+meth public void setValidating(boolean) throws jakarta.xml.bind.JAXBException
 supr java.lang.Object
 hfds eventHandler,reader
 
-CLSS public javax.xml.bind.helpers.DefaultValidationEventHandler
+CLSS public jakarta.xml.bind.helpers.DefaultValidationEventHandler
 cons public DefaultValidationEventHandler()
-intf javax.xml.bind.ValidationEventHandler
-meth public boolean handleEvent(javax.xml.bind.ValidationEvent)
+intf jakarta.xml.bind.ValidationEventHandler
+meth public boolean handleEvent(jakarta.xml.bind.ValidationEvent)
 supr java.lang.Object
 
-CLSS public javax.xml.bind.helpers.NotIdentifiableEventImpl
-cons public NotIdentifiableEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator)
-cons public NotIdentifiableEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator,java.lang.Throwable)
-intf javax.xml.bind.NotIdentifiableEvent
-supr javax.xml.bind.helpers.ValidationEventImpl
+CLSS public jakarta.xml.bind.helpers.NotIdentifiableEventImpl
+cons public NotIdentifiableEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator)
+cons public NotIdentifiableEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator,java.lang.Throwable)
+intf jakarta.xml.bind.NotIdentifiableEvent
+supr jakarta.xml.bind.helpers.ValidationEventImpl
 
-CLSS public javax.xml.bind.helpers.ParseConversionEventImpl
-cons public ParseConversionEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator)
-cons public ParseConversionEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator,java.lang.Throwable)
-intf javax.xml.bind.ParseConversionEvent
-supr javax.xml.bind.helpers.ValidationEventImpl
+CLSS public jakarta.xml.bind.helpers.ParseConversionEventImpl
+cons public ParseConversionEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator)
+cons public ParseConversionEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator,java.lang.Throwable)
+intf jakarta.xml.bind.ParseConversionEvent
+supr jakarta.xml.bind.helpers.ValidationEventImpl
 
-CLSS public javax.xml.bind.helpers.PrintConversionEventImpl
-cons public PrintConversionEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator)
-cons public PrintConversionEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator,java.lang.Throwable)
-intf javax.xml.bind.PrintConversionEvent
-supr javax.xml.bind.helpers.ValidationEventImpl
+CLSS public jakarta.xml.bind.helpers.PrintConversionEventImpl
+cons public PrintConversionEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator)
+cons public PrintConversionEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator,java.lang.Throwable)
+intf jakarta.xml.bind.PrintConversionEvent
+supr jakarta.xml.bind.helpers.ValidationEventImpl
 
-CLSS public javax.xml.bind.helpers.ValidationEventImpl
-cons public ValidationEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator)
-cons public ValidationEventImpl(int,java.lang.String,javax.xml.bind.ValidationEventLocator,java.lang.Throwable)
-intf javax.xml.bind.ValidationEvent
+CLSS public jakarta.xml.bind.helpers.ValidationEventImpl
+cons public ValidationEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator)
+cons public ValidationEventImpl(int,java.lang.String,jakarta.xml.bind.ValidationEventLocator,java.lang.Throwable)
+intf jakarta.xml.bind.ValidationEvent
 meth public int getSeverity()
 meth public java.lang.String getMessage()
 meth public java.lang.String toString()
 meth public java.lang.Throwable getLinkedException()
-meth public javax.xml.bind.ValidationEventLocator getLocator()
+meth public jakarta.xml.bind.ValidationEventLocator getLocator()
 meth public void setLinkedException(java.lang.Throwable)
-meth public void setLocator(javax.xml.bind.ValidationEventLocator)
+meth public void setLocator(jakarta.xml.bind.ValidationEventLocator)
 meth public void setMessage(java.lang.String)
 meth public void setSeverity(int)
 supr java.lang.Object
 hfds linkedException,locator,message,severity
 
-CLSS public javax.xml.bind.helpers.ValidationEventLocatorImpl
+CLSS public jakarta.xml.bind.helpers.ValidationEventLocatorImpl
 cons public ValidationEventLocatorImpl()
 cons public ValidationEventLocatorImpl(java.lang.Object)
 cons public ValidationEventLocatorImpl(org.w3c.dom.Node)
 cons public ValidationEventLocatorImpl(org.xml.sax.Locator)
 cons public ValidationEventLocatorImpl(org.xml.sax.SAXParseException)
-intf javax.xml.bind.ValidationEventLocator
+intf jakarta.xml.bind.ValidationEventLocator
 meth public int getColumnNumber()
 meth public int getLineNumber()
 meth public int getOffset()
@@ -994,25 +994,25 @@ meth public void setURL(java.net.URL)
 supr java.lang.Object
 hfds columnNumber,lineNumber,node,object,offset,url
 
-CLSS public javax.xml.bind.util.JAXBResult
-cons public JAXBResult(javax.xml.bind.JAXBContext) throws javax.xml.bind.JAXBException
-cons public JAXBResult(javax.xml.bind.Unmarshaller) throws javax.xml.bind.JAXBException
-meth public java.lang.Object getResult() throws javax.xml.bind.JAXBException
+CLSS public jakarta.xml.bind.util.JAXBResult
+cons public JAXBResult(jakarta.xml.bind.JAXBContext) throws jakarta.xml.bind.JAXBException
+cons public JAXBResult(jakarta.xml.bind.Unmarshaller) throws jakarta.xml.bind.JAXBException
+meth public java.lang.Object getResult() throws jakarta.xml.bind.JAXBException
 supr javax.xml.transform.sax.SAXResult
 hfds unmarshallerHandler
 
-CLSS public javax.xml.bind.util.JAXBSource
-cons public JAXBSource(javax.xml.bind.JAXBContext,java.lang.Object) throws javax.xml.bind.JAXBException
-cons public JAXBSource(javax.xml.bind.Marshaller,java.lang.Object) throws javax.xml.bind.JAXBException
+CLSS public jakarta.xml.bind.util.JAXBSource
+cons public JAXBSource(jakarta.xml.bind.JAXBContext,java.lang.Object) throws jakarta.xml.bind.JAXBException
+cons public JAXBSource(jakarta.xml.bind.Marshaller,java.lang.Object) throws jakarta.xml.bind.JAXBException
 supr javax.xml.transform.sax.SAXSource
 hfds contentObject,marshaller,pseudoParser
 
-CLSS public javax.xml.bind.util.ValidationEventCollector
+CLSS public jakarta.xml.bind.util.ValidationEventCollector
 cons public ValidationEventCollector()
-intf javax.xml.bind.ValidationEventHandler
-meth public boolean handleEvent(javax.xml.bind.ValidationEvent)
+intf jakarta.xml.bind.ValidationEventHandler
+meth public boolean handleEvent(jakarta.xml.bind.ValidationEvent)
 meth public boolean hasEvents()
-meth public javax.xml.bind.ValidationEvent[] getEvents()
+meth public jakarta.xml.bind.ValidationEvent[] getEvents()
 meth public void reset()
 supr java.lang.Object
 hfds events


### PR DESCRIPTION
I'm not versed in how this TCK works.  If this update is not helpful it's ok to close.

The guess is that the `/sig/9.0/jakarta.xml.bind.sig` file is the right one for Jakarta EE 9 and needs updating but the other signature files `/sig/7.0/jakarta.xml.bind.sig`, etc are for older releases and do not need to be updated.