### PR TITLE
updating copyright year

### DIFF
--- a/jaxb-tck/src/share/coverage/BindingXMLSchemaToJava.html
+++ b/jaxb-tck/src/share/coverage/BindingXMLSchemaToJava.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxb-tck/src/share/coverage/CustomizingXMLSchema.html
+++ b/jaxb-tck/src/share/coverage/CustomizingXMLSchema.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxb-tck/src/share/coverage/JavaTypes2XML.html
+++ b/jaxb-tck/src/share/coverage/JavaTypes2XML.html
@@ -3,7 +3,7 @@
 <head>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxb-tck/src/share/jttck/classes/com/sun/jaxb_tck/lib/JaxbTckScript.java
+++ b/jaxb-tck/src/share/jttck/classes/com/sun/jaxb_tck/lib/JaxbTckScript.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxb-tck/tests/api/signaturetest/sig/9.0/jakarta.xml.bind.sig
+++ b/jaxb-tck/tests/api/signaturetest/sig/9.0/jakarta.xml.bind.sig
@@ -2,7 +2,7 @@
 #Version 
 
 #
-# Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at

--- a/jaxb-tck/tests/java2schema/CustomizedMapping/classes/XmlType/basetype/BaseType002d.java
+++ b/jaxb-tck/tests/java2schema/CustomizedMapping/classes/XmlType/basetype/BaseType002d.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
This PR contains the Copyright year updates for the files changes as part of  https://github.com/eclipse-ee4j/jaxb-tck/pull/27/ and https://github.com/eclipse-ee4j/jaxb-tck/pull/26/

Signed-off-by: RohitKumarJain <rohit.ku.jain@oracle.com>