### PR TITLE
Rename LICENSE_EFTL.md to LINCENSE.md

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -60,8 +60,10 @@
           description="copy the file">
     <mkdir dir="${dist}"/>
     <mkdir dir="${dist}/${bundle.folder}"/>
-      <copy file="LICENSE_EFTL.md" tofile="LICENSE.md"/>
+      <move file="LICENSE.md" tofile="LICENSE1.md"/>
+      <copy file="LICENSE_EFTL.md" tofile="LICENSE.md" />
       <copy file="LICENSE.md" todir="${dist}/${bundle.folder}"/>
+      <move file="LICENSE1.md" tofile="LICENSE.md"/>
   </target>
   
   <target name="dist_eftl" depends="clean"

--- a/build.xml
+++ b/build.xml
@@ -60,7 +60,8 @@
           description="copy the file">
     <mkdir dir="${dist}"/>
     <mkdir dir="${dist}/${bundle.folder}"/>
-      <copy file="LICENSE_EFTL.md" todir="${dist}/${bundle.folder}"/>
+      <copy file="LICENSE_EFTL.md" tofile="LICENSE.md"/>
+      <copy file="LICENSE.md" todir="${dist}/${bundle.folder}"/>
   </target>
   
   <target name="dist_eftl" depends="clean"


### PR DESCRIPTION
	Successfully tested the changes while triggering job in CI for the below scenario: 
   
- LICENSE as EPL (https://ci.eclipse.org/jakartaee-tck/job/rjain-jaxb/job/renameEFTL/4/). 

- LICENSE as EFTL (https://ci.eclipse.org/jakartaee-tck/job/rjain-jaxb/job/renameEFTL/3/). 

I have verified the changes as well in the bundle.