### PR TITLE
#128: replace absolute paths with relative ones in test config files

### DIFF
--- a/docker/run_jaxbtck.sh
+++ b/docker/run_jaxbtck.sh
@@ -48,12 +48,10 @@ elif [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
   wget ${WGET_PROPS} https://download.java.net/java/GA/jdk21.0.1/415e3f918a1f4062a0074a2794853d0d/12/GPL/openjdk-21.0.1_linux-x64_bin.tar.gz -O jdk-21.tar.gz
   tar -xvf jdk-21.tar.gz
   export JAVA_HOME=$WORKSPACE/jdk-21.0.1
-fi  
-    
-sed -i "s#^jck.env.jaxb.testExecute.cmdAsFile=.*#jck.env.jaxb.testExecute.cmdAsFile=${JAVA_HOME}/bin/java#g" ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti
-sed -i "s#^WORKDIR=.*#WORKDIR=${WORKSPACE}/${TCK_NAME}/batch-multiJVM/work/#g" ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti
-sed -i "s#^TESTSUITE=.*#TESTSUITE=${WORKSPACE}/${TCK_NAME}/#g" ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti
+fi
 
+sed -i "s#^jck.env.jaxb.testExecute.otherOpts=.*#jck.env.jaxb.testExecute.otherOpts=-Djdk.xml.elementAttributeLimit=2000#g" ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti
+sed -i "s#^jck.env.jaxb.testExecute.cmdAsFile=.*#jck.env.jaxb.testExecute.cmdAsFile=${JAVA_HOME}/bin/java#g" ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti
 
 if [[ "$RUNTIME" == "Glassfish" ]]; then
   sed -i "s#^jck.env.jaxb.testExecute.otherEnvVars=.*#jck.env.jaxb.testExecute.otherEnvVars=JAVA_HOME\=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish#g" ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti
@@ -108,25 +106,25 @@ chmod -R 777 ${TOP_GLASSFISH_DIR}
 
 mkdir -p JAXB_REPORT/JAXB-TCK
 
-cd ${TCK_NAME}/tests/api/signaturetest
+cd ${TCK_NAME}
 
 ####RUN tests with GLassfish JAXB
 if [[ "$RUNTIME" == "Glassfish" ]]; then
-	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir -create ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.xsd_compiler.testCompile.xjcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/xjc.sh" -set jck.env.jaxb.schemagen.run.jxcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/schemagen.sh" -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.xml.bind-api.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jaxb-osgi.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jersey-media-jaxb.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.activation-api.jar ${WORKSPACE}/checker.jar" -set jck.env.jaxb.classes.needJaxbClasses Yes -runtests
-	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.xsd_compiler.testCompile.xjcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/xjc.sh" -set jck.env.jaxb.schemagen.run.jxcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/schemagen.sh" -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.xml.bind-api.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jaxb-osgi.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jersey-media-jaxb.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.activation-api.jar ${WORKSPACE}/checker.jar" -set jck.env.jaxb.classes.needJaxbClasses Yes -set jck.priorStatus.needStatus Yes -set jck.priorStatus.status not_run -runtests
+	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir -create ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.xml.bind-api.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jaxb-osgi.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jersey-media-jaxb.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.activation-api.jar ${WORKSPACE}/checker.jar" -runtests
+	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.xml.bind-api.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jaxb-osgi.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jersey-media-jaxb.jar ${WORKSPACE}/${TOP_GLASSFISH_DIR}/glassfish/modules/jakarta.activation-api.jar ${WORKSPACE}/checker.jar" -set jck.priorStatus.needStatus Yes -set jck.priorStatus.status not_run -runtests
 else 
 ####RUN tests with standalone JAXB RI
-	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir -create ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.xsd_compiler.testCompile.xjcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/xjc.sh" -set jck.env.jaxb.schemagen.run.jxcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/schemagen.sh" -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/jaxb-ri" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/checker.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.xml.bind-api.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-impl.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-jxc.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.activation-api.jar" -set jck.env.jaxb.classes.needJaxbClasses Yes -runtests
-	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.xsd_compiler.testCompile.xjcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/xjc.sh" -set jck.env.jaxb.schemagen.run.jxcCmd "/bin/sh ${WORKSPACE}/${TCK_NAME}/linux/bin/schemagen.sh" -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/jaxb-ri" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/checker.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.xml.bind-api.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-impl.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-jxc.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.activation-api.jar" -set jck.env.jaxb.classes.needJaxbClasses Yes -set jck.priorStatus.needStatus Yes -set jck.priorStatus.status not_run -runtests
+	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir -create ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/jaxb-ri" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/checker.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.xml.bind-api.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-impl.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-jxc.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.activation-api.jar" -runtests
+	$JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -batch -testsuite ${WORKSPACE}/${TCK_NAME} -open ${WORKSPACE}/${TCK_NAME}/lib/javasoft-multiJVM.jti -workdir ${WORKSPACE}/batch-multiJVM/work -set jck.env.jaxb.xsd_compiler.skipValidationOptional Yes -set jck.env.jaxb.testExecute.otherEnvVars "JAVA_HOME=${JAVA_HOME} JAXB_HOME=${WORKSPACE}/jaxb-ri" -set jck.env.jaxb.classes.jaxbClasses "${WORKSPACE}/checker.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.xml.bind-api.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-impl.jar ${WORKSPACE}/jaxb-ri/mod/jaxb-jxc.jar ${WORKSPACE}/jaxb-ri/mod/jakarta.activation-api.jar" -set jck.priorStatus.needStatus Yes -set jck.priorStatus.status not_run -runtests
 fi
 
   $JAVA_HOME/bin/java -DnoSecurityManager=true -jar ${WORKSPACE}/${TCK_NAME}/lib/javatest.jar -workdir ${WORKSPACE}/batch-multiJVM/work -writereport ${WORKSPACE}/JAXB_REPORT/JAXB-TCK
 
 
+cd ${WORKSPACE}
 export HOST=`hostname -f`
-echo "1 JAXB-TCK ${HOST}" > ${WORKSPACE}/args.txt
+echo "1 JAXB-TCK ${HOST}" > args.txt
 mkdir -p ${WORKSPACE}/results/junitreports/
 ${JAVA_HOME}/bin/java -Djunit.embed.sysout=true -jar ${WORKSPACE}/docker/JTReportParser/JTReportParser.jar ${WORKSPACE}/args.txt ${WORKSPACE}/JAXB_REPORT ${WORKSPACE}/results/junitreports/
-rm -f ${WORKSPACE}/args.txt
-cd ${WORKSPACE}
-tar zcvf jaxbtck-results.tar.gz ${WORKSPACE}/JAXB_REPORT ${WORKSPACE}/batch-multiJVM/work ${WORKSPACE}/results/junitreports/
+rm -f args.txt
+tar zcvf jaxbtck-results.tar.gz JAXB_REPORT batch-multiJVM/work results/junitreports/

--- a/jaxb-tck/build/test.mk
+++ b/jaxb-tck/build/test.mk
@@ -57,7 +57,7 @@ precompile_testsuite_jtt.ok: $(TCKDIR)
 	echo "name=JAXB TCK testsuite" > $(TCKDIR)/testsuite.jtt
 	echo "id=jaxb_tck22" >> $(TCKDIR)/testsuite.jtt
 	echo "classpath=./classes/:$(PRECOMPILEDIR)/classes" >> $(TCKDIR)/testsuite.jtt
-	echo "finder=com.sun.javatest.finder.BinaryTestFinder -binary $(TCKDIR)/tests/testsuite.jtd" >> $(TCKDIR)/testsuite.jtt
+	echo "finder=com.sun.javatest.finder.BinaryTestFinder -binary testsuite.jtd" >> $(TCKDIR)/testsuite.jtt
 	echo "script=com.sun.jaxb_tck.lib.PrecompileJaxbTckScript" >> $(TCKDIR)/testsuite.jtt
 	echo "testsuite.jtt for precompile built at `date`" > $@
 
@@ -82,9 +82,8 @@ $(TCKDIR)/lib/javasoft-singleJVM.jti: precompile-jti-gen.ok $(@D)
 	@ $(RM) $@
 	CLASSPATH=classes:$(JAVATEST_JAR_LOC)/javatest.jar:$(TOPDIR)/src/tools/jti/target/classes \
 	$(GENERAL_JAVA) com.sun.jaxb_tck.util.JtiGen -single \
-	-work $(BUILDAREA)/test/$(TCKVERSION)/batch-singleJVM/work \
-	-testsuite $(UNZIPDIR)/$(TCKVERSION) \
-	-ri_java_home $(PRECOMPILE_JAVAHOME) \
+	-work batch-singleJVM/work \
+	-testsuite . \
 	-tests $(INITIALURLS) > $@
 	@echo "**** javasoft-singleJVM.jti created at `date` ****"
 	
@@ -92,14 +91,11 @@ $(TCKDIR)/lib/javasoft-multiJVM.jti: precompile-jti-gen.ok $(@D)
 	@ $(RM) $@
 	CLASSPATH=classes:$(JAVATEST_JAR_LOC)/javatest.jar:$(TOPDIR)/src/tools/jti/target/classes \
 	$(GENERAL_JAVA) com.sun.jaxb_tck.util.JtiGen -multi \
-	-work $(BUILDAREA)/test/$(TCKVERSION)/batch-multiJVM/work \
-	-testsuite $(UNZIPDIR)/$(TCKVERSION) \
+	-work batch-multiJVM/work \
+	-testsuite . \
 	-tests $(INITIALURLS) \
-	-ri_java_home $(PRECOMPILE_JAVAHOME) \
-	-xsd_compiler "/bin/ksh solaris/bin/xjc.sh" \
-	-schemagen "/bin/ksh solaris/bin/schemagen.sh" \
-	-jaxb `echo $(JAXB_CLASSPATH) | sed 's/:/ /g'` \
-	-otherEnv JAVA_HOME=$(PRECOMPILE_JAVAHOME) `if [ -z "$(JCK_JAXB)" ]; then echo "JAXB_HOME=$(JAXB_HOME)"; fi` > $@
+	-xsd_compiler "/bin/sh linux/bin/xjc.sh" \
+	-schemagen "/bin/sh linux/bin/schemagen.sh" > $@
 	@echo "**** javasoft-multiJVM.jti created at `date` ****"
 
 ZIP.files += $(TCKDIR)/lib/javasoft-multiJVM.jti $(TCKDIR)/lib/javasoft-singleJVM.jti

--- a/jaxb-tck/build/zip.mk
+++ b/jaxb-tck/build/zip.mk
@@ -31,7 +31,7 @@ test_run_testsuite_jtt.ok: $(ZIP.files)
 	echo "$(shell $(TEST_SUITE_SCRIPT.sh))" >> $(TCKDIR)/testsuite.jtt
 	echo "$(shell $(TEST_EXECUTE_SCRIPT.sh))" >> $(TCKDIR)/testsuite.jtt
 	echo "$(PWD)"
-	echo "finder=com.sun.javatest.finder.BinaryTestFinder -binary $(TCKDIR)/tests/testsuite.jtd" >> $(TCKDIR)/testsuite.jtt
+	echo "finder=com.sun.javatest.finder.BinaryTestFinder -binary testsuite.jtd" >> $(TCKDIR)/testsuite.jtt
 	echo "interview=com.sun.jaxb_tck.interview.JAXBTCKParameters" >> $(TCKDIR)/testsuite.jtt
 	echo "initial.jtx=lib/$(EXCLUDE_LIST)" >> $(TCKDIR)/testsuite.jtt
 	echo "testsuite.jtt for test run built at `date`" > $@

--- a/jaxb-tck/src/docs/userguide/src/main/jbake/content/config.adoc
+++ b/jaxb-tck/src/docs/userguide/src/main/jbake/content/config.adoc
@@ -114,8 +114,8 @@ jck.env.jaxb.classes.jaxbClasses=/data/tck/tmp/checker.jar
 jck.env.jaxb.schemagen.run.jxcCmd=/bin/sh
   /workspace/XMLB-TCK-4.0/linux/bin/schemagen.sh
 jck.env.jaxb.schemagen.skipJ2XOptional=Yes
-jck.env.jaxb.testExecute.cmdAsFile=/opt/jdk1.8.0_192.jdk/bin/java
-jck.env.jaxb.testExecute.otherEnvVars=JAVA_HOME\=/opt/jdk1.8.0_192.jdk
+jck.env.jaxb.testExecute.cmdAsFile=/opt/jdk11/bin/java
+jck.env.jaxb.testExecute.otherEnvVars=JAVA_HOME\=/opt/jdk11
   JAXB_HOME\=/workspace/jaxb-ri
 jck.env.jaxb.testExecute.otherOpts=
 jck.env.jaxb.xsd_compiler.defaultOperationMode=Yes

--- a/jaxb-tck/src/tools/jti/src/main/java/com/sun/jaxb_tck/util/JtiGen.java
+++ b/jaxb-tck/src/tools/jti/src/main/java/com/sun/jaxb_tck/util/JtiGen.java
@@ -26,10 +26,10 @@ import com.sun.interview.Interview;
 public class JtiGen extends Interview {
 
     private static final String USAGE =
-        "Usage: java com.sun.jaxp_tck.util.JtiGen -single -work dir "
+        "Usage: java com.sun.jaxb_tck.util.JtiGen -single -work dir "
         + "-testsuite dir -tests testURLs "
         + "\n"
-        + "java com.sun.jaxp_tck.util.JtiGen -multi -work dir "
+        + "java com.sun.jaxb_tck.util.JtiGen -multi -work dir "
         + "-testsuite dir -tests testURLs -jvm file -xsd_compiler file "
         + "-jaxb JAXB_CLASSES -otherEnv name=value -tests testURLs ";
 
@@ -47,6 +47,7 @@ public class JtiGen extends Interview {
 
         this.data.put("jck.concurrency.concurrency", "1");
         this.data.put("jck.env.jaxb.xsd_compiler.defaultOperationMode", "Yes");
+        this.data.put("jck.env.jaxb.testExecute.cmdAsFile", "java");
         this.data.put("jck.env.jaxb.testExecute.otherEnvVars", "");
         this.data.put("jck.env.testPlatform.local", "Yes");
         this.data.put("jck.excludeList.latestAutoCheck", "No");
@@ -73,12 +74,15 @@ public class JtiGen extends Interview {
             this.data.put("jck.env.testPlatform.multiJVM", "No");
             this.data.put("jck.env.jaxb.schemagen.run.schemagenWrapperClass", "com.sun.jaxb_tck.lib.SchemaGen");
         } else {
-            this.data.put("jck.env.jaxb.xsd_compiler.testCompile.xjcCmd", "/bin/ksh solaris/bin/xjc.sh");
+            this.data.put("jck.env.jaxb.xsd_compiler.testCompile.xjcCmd", "/bin/sh linux/bin/xjc.sh");
             this.data.put("jck.env.description", "multi jvm");
             this.data.put("jck.env.envName", "multi_jvm");
             this.data.put("jck.env.testPlatform.multiJVM", "Yes");
             this.data.put("jck.env.jaxb.testExecute.otherOpts", "");
-            this.data.put("jck.env.jaxb.schemagen.run.jxcCmd", "/bin/ksh solaris/bin/schemagen.sh");
+            this.data.put("jck.env.jaxb.schemagen.run.jxcCmd", "/bin/sh linux/bin/schemagen.sh");
+            this.data.put("jck.env.jaxb.classes.needJaxbClasses", "Yes");
+            this.data.put("jck.env.jaxb.classes.jaxbClasses", "");
+
         }
         this.data.putAll(data);
     }


### PR DESCRIPTION
fixes #128 and changes default solaris scripts to linux ones