### PR TITLE
Remove direct use of SecurityManager

### DIFF
--- a/jaxb-tck/src/tools/jttck/jaxb_tck/lib/src/main/java/com/sun/jaxb_tck/lib/Jxc.java
+++ b/jaxb-tck/src/tools/jttck/jaxb_tck/lib/src/main/java/com/sun/jaxb_tck/lib/Jxc.java
@@ -29,17 +29,11 @@ public class Jxc extends CompositeInvoker {
     private boolean isSetIOAllowed;
 
     {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null) {
+        try {
+            new RuntimePermission("setIO").checkGuard(null);
             isSetIOAllowed = true;
-        } else {
-            try {
-                sm.checkPermission(new RuntimePermission("setIO"));
-
-                isSetIOAllowed = true;
-            } catch (SecurityException e) {
-                isSetIOAllowed = false;
-            }
+        } catch (SecurityException e) {
+            isSetIOAllowed = false;
         }
     }
 
@@ -74,7 +68,6 @@ public class Jxc extends CompositeInvoker {
         } finally {
             err.flush();
             out.flush();
-
             if (isSetIOAllowed) {
                 System.setOut(oldSystemOut);
                 System.setErr(oldSystemErr);

--- a/jaxb-tck/src/tools/jttck/jaxb_tck/lib/src/main/java/com/sun/jaxb_tck/lib/Xjc.java
+++ b/jaxb-tck/src/tools/jttck/jaxb_tck/lib/src/main/java/com/sun/jaxb_tck/lib/Xjc.java
@@ -29,16 +29,11 @@ public class Xjc extends CompositeInvoker{
     private boolean isSetIOAllowed;
 
     {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null) {
+        try {
+            new RuntimePermission("setIO").checkGuard(null);
             isSetIOAllowed = true;
-        } else {
-            try {
-                sm.checkPermission(new RuntimePermission("setIO"));
-                isSetIOAllowed = true;
-            } catch (SecurityException e) {
-                isSetIOAllowed = false;
-            }
+        } catch (SecurityException e) {
+            isSetIOAllowed = false;
         }
     }
 
@@ -65,8 +60,7 @@ public class Xjc extends CompositeInvoker{
      *  Performs the schema generation
      */
     @Override
-    protected int execute(PrintStream out, PrintStream err) throws Exception
-    {
+    protected int execute(PrintStream out, PrintStream err) throws Exception {
         PrintStream oldSystemOut = System.out;
         PrintStream oldSystemErr = System.err;
         try {


### PR DESCRIPTION
this is going to postpone deprecation warnings to SE 25 where RuntimePermission became deprecated for removal too.