### PR TITLE
#166: remove dependency on checker.jar from userguide

### DIFF
--- a/jaxb-tck/src/docs/userguide/src/main/jbake/content/config.adoc
+++ b/jaxb-tck/src/docs/userguide/src/main/jbake/content/config.adoc
@@ -71,9 +71,8 @@ compiler refers to both the schema compiler and the schema generator.
   b.  Set `WORKDIR` environment variable to contain {TechnologyShortName}
       TCK software working directory. This directory will contain raw testing
       data and results.
-  c.  Set `jck.env.jaxb.classes.jaxbClasses` property to contain The Checker
-      Framework library and all {TechnologyShortName} libraries:
-        * checker.jar
+  c.  Set `jck.env.jaxb.classes.jaxbClasses` property to contain all
+      {TechnologyShortName} libraries:
         * +{TechnologyHomeEnv}+/mod/jakarta.activation-api.jar
         * +{TechnologyHomeEnv}+/mod/jakarta.xml.bind-api.jar
         * +{TechnologyHomeEnv}+/mod/jaxb-core.jar
@@ -105,7 +104,7 @@ WORKDIR=/workspace/XMLB-TCK-4.0/batch-multiJVM/work
 jck.concurrency.concurrency=1
 jck.env.description=multi jvm
 jck.env.envName=multi_jvm
-jck.env.jaxb.classes.jaxbClasses=/data/tck/tmp/checker.jar
+jck.env.jaxb.classes.jaxbClasses=
   /data/tck/tmp/jaxb-ri/mod/jakarta.activation-api.jar
   /data/tck/tmp/jaxb-ri/mod/jakarta.xml.bind-api.jar
   /data/tck/tmp/jaxb-ri/mod/jaxb-core.jar

--- a/jaxb-tck/src/docs/userguide/src/main/jbake/content/install.adoc
+++ b/jaxb-tck/src/docs/userguide/src/main/jbake/content/install.adoc
@@ -42,8 +42,7 @@ install and set up the following software components:
 include::req-software.inc[]
 * Java SE {SEversion}
 * A CI for {TechnologyShortName} {TechnologyVersion}, one example is {TechnologyRI}
-* {TechnologyShortName} TCK version {TechnologyVersion}, which includes:
-include::tck-packages.inc[]
+* {TechnologyShortName} TCK version {TechnologyVersion}
 * The {TechnologyShortName} {TechnologyVersion} Vendor Implementation (VI)
 
 Follow these steps:

--- a/jaxb-tck/src/docs/userguide/src/main/jbake/content/intro.adoc
+++ b/jaxb-tck/src/docs/userguide/src/main/jbake/content/intro.adoc
@@ -333,8 +333,7 @@ on the system hosting the JavaTest harness:
 include::req-software.inc[]
 * Java SE {SEversion}
 * A CI for {TechnologyShortName} {TechnologyVersion}. One example is {TechnologyRI}.
-* {TechnologyShortName} TCK version {TechnologyVersion}, which includes:
-include::tck-packages.inc[]
+* {TechnologyShortName} TCK version {TechnologyVersion}
 * The {TechnologyShortName} {TechnologyVersion} Vendor Implementation (VI)
 --
 See the documentation for each of these software applications for


### PR DESCRIPTION
could be seen as breaking change, so let's wait with removing mentions about checker from the user guide for the new minor version

fixes #166 