### PR TITLE
Bump org.eclipse.ee4j:project in /jaxb-tck/src in the dependencies group

### DIFF
--- a/jaxb-tck/src/pom.xml
+++ b/jaxb-tck/src/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>2.0.2</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
Bumps the dependencies group in /jaxb-tck/src with 1 update: [org.eclipse.ee4j:project](https://github.com/eclipse-ee4j/ee4j).

Updates `org.eclipse.ee4j:project` from 2.0.2 to 2.0.3
- [Release notes](https://github.com/eclipse-ee4j/ee4j/releases)
- [Commits](https://github.com/eclipse-ee4j/ee4j/compare/2.0.2...2.0.3)

---
updated-dependencies:
- dependency-name: org.eclipse.ee4j:project dependency-version: 2.0.3 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: dependencies ...


(cherry picked from commit 8a92f57888f8357f60048399e5bca94907702189)