### PR TITLE
Bump org.apache.maven.plugins:maven-enforcer-plugin

### DIFF
--- a/jaxb-tck/src/pom.xml
+++ b/jaxb-tck/src/pom.xml
@@ -214,7 +214,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.6.2</version>
+                    <version>3.6.3</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Bumps the maven-plugins group in /jaxb-tck/src with 1 update: [org.apache.maven.plugins:maven-enforcer-plugin](https://github.com/apache/maven-enforcer).

Updates `org.apache.maven.plugins:maven-enforcer-plugin` from 3.6.2 to 3.6.3
- [Release notes](https://github.com/apache/maven-enforcer/releases)
- [Commits](https://github.com/apache/maven-enforcer/compare/enforcer-3.6.2...enforcer-3.6.3)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-enforcer-plugin dependency-version: 3.6.3 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: maven-plugins ...


(cherry picked from commit eb2e358ee8965a5b706e17bebee4682ba7cc74c8)